### PR TITLE
Search Contacts/Search Partners

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'rack-cors'
 
 gem 'json'
 
+gem 'pg_search'
+
 gem "validate_url"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,10 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     pg (0.20.0)
+    pg_search (2.0.1)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      arel (>= 6)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -242,6 +246,7 @@ DEPENDENCIES
   knock (~> 2.1, >= 2.1.1)
   listen (~> 3.0.5)
   pg
+  pg_search
   puma (~> 3.0)
   rack-cors
   rails (~> 5.0.2)

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -4,7 +4,12 @@ class ContactsController < ApplicationController
   before_action :set_contact_links, only: [:show]
 
   def index
-    contacts = Contact.all.each {| c | set_self_link c }
+    if params[:search]
+      contacts = Contact.search(params[:search])
+    else
+      contacts = Contact.all
+    end
+    contacts.each {| c | set_self_link c }
     render_list_of contacts
   end
 
@@ -36,7 +41,12 @@ class ContactsController < ApplicationController
   end
 
   def partners
-    partners = Contact.partners.each {| c | set_self_link c }
+    if params[:search]
+      partners = Contact.partners.search(params[:search])
+    else
+      partners = Contact.partners
+    end
+    partners.each {| c | set_self_link c }
     render_list_of partners
   end
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,4 +1,6 @@
 class Contact < Linkable
+  include PgSearch
+
   VALID_NAME_REGEX = /[a-zA-Z]/i
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   before_save { self.email.downcase! }
@@ -18,6 +20,22 @@ class Contact < Linkable
                          allow_nil: true
 
   has_and_belongs_to_many :groups
+
+  pg_search_scope :search, :against => {
+                                            :first_name => 'A',
+                                            :last_name => 'A',
+                                            :email => 'B',
+                                            :business_name => 'B',
+                                            :street_address => 'C',
+                                            :city => 'C',
+                                            :state => 'D',
+                                            :zip => 'D',
+                                            :phone => 'D',
+                                            :phone_alt => 'D'
+                                        },
+                                        :using => {
+                                          :tsearch => { :prefix => true }
+                                        }
 
   scope :partners, -> { where(partner: true) }
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,6 +1,7 @@
 class Link < Linkable
   validates :title, presence: true, length: { minimum: 2 }
   validates :destination, presence: true, length: { minimum: 12, maximum: 256 }, :url => true
-
+  validates_presence_of :group
+  
   belongs_to :group
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,5 +1,7 @@
 class Note < Linkable
   validates :content, presence: true, length: { minimum: 25 }
+  validates_presence_of :user
+  validates_presence_of :group
 
   belongs_to :user
   belongs_to :group

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170408141330) do
+ActiveRecord::Schema.define(version: 20170430091258) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/features/contacts/search_contacts.feature
+++ b/features/contacts/search_contacts.feature
@@ -1,0 +1,210 @@
+Feature: Search Contacts
+  In order to find the contacts I want
+  I need to be able to search for them in multiple fields.
+
+  Background:
+    Given the following user is registered:
+      | first_name       | last_name      | email                       | password  |
+      | Charles          | Xavier         | x@westchester.ny            | jeanrules |
+
+    And the system knows about the following contacts:
+      | first_name       | last_name      | email                     | business_name        | street_address               | city      | state | zip   | phone |
+      | Reed             | Richards       | mrfantastic@ff.org        | Fantastic Four       | Madison Avenue               | New York  | NY    | 18019 | 1800444444 |
+      | Jessica          | Jones          | jewel@brooklyn.ny         | Alias Investigations | 485 W 46th Street            | New York  | NY    | 10036 | 1800555321 |
+      | Richard          | Jones          | abomb@smash.org           | Hulk, Inc            | 7324 E Indian School Road    | Scarsdale | AZ    | 18321 |            |
+
+    And the client authenticates as x@westchester.ny/jeanrules
+
+  Scenario: Search contacts (unauthenticated client)
+    Given the client is not authenticated
+    When the client sends a GET request to /contacts?search=Jones
+    Then a 401 status code is returned
+
+
+  Scenario: Search contacts resulting in no match
+    Given the client sends a GET request to /contacts?search=mxyzptlk@5th.dimension
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly no contacts
+
+    
+  Scenario: Search contacts matching on last name only
+    Given the client sends a GET request to /contacts?search=Jones
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly two contacts
+    And the JSON should contain:
+      """
+        [
+          { "first_name": "Jessica", "last_name": "Jones", "email": "jewel@brooklyn.ny" },
+          { "first_name": "Richard", "last_name": "Jones", "email": "abomb@smash.org" }
+        ]
+      """
+
+
+  Scenario: Search contacts matching on last name, with a mixed case query
+    Given the client sends a GET request to /contacts?search=JoNEs
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly two contacts
+    And the JSON should contain:
+      """
+        [
+          { "first_name": "Jessica", "last_name": "Jones", "email": "jewel@brooklyn.ny" },
+          { "first_name": "Richard", "last_name": "Jones", "email": "abomb@smash.org" }
+        ]
+      """
+
+
+  Scenario: Search contacts matching on exact email address only
+    Given the client sends a GET request to /contacts?search=mrfantastic@ff.org
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly one contact
+    And the JSON should contain:
+      """
+        [
+          { "first_name": "Reed", "last_name": "Richards", "email": "mrfantastic@ff.org" }
+        ]
+      """
+
+
+  Scenario: Search contacts matching on an email address starting with a value
+    Given the client sends a GET request to /contacts?search=mrfantastic
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly one contact
+    And the JSON should contain:
+      """
+        [
+          { "first_name": "Reed", "last_name": "Richards", "email": "mrfantastic@ff.org" }
+        ]
+      """
+
+
+  Scenario: Search contacts matching on an email address containing with a value
+            pg_search does not support contains matching on email addresses
+    Given the client sends a GET request to /contacts?search=ff
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly no contacts
+
+
+  Scenario: Search contacts matching on an email address ending with a value
+            pg_search does not support ends with matching on email addresses
+    Given the client sends a GET request to /contacts?search=org
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly no contacts
+
+
+  Scenario: Search contacts matching on business name only
+    Given the client sends a GET request to /contacts?search=In
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly two contacts
+    And the JSON should contain:
+      """
+        [
+          { "first_name": "Jessica", "last_name": "Jones", "email": "jewel@brooklyn.ny", "business_name": "Alias Investigations" },
+          { "first_name": "Richard", "last_name": "Jones", "email": "abomb@smash.org", "business_name": "Hulk, Inc" }
+        ]
+      """
+
+
+  Scenario: Search contacts matching on exact phone number
+    Given the client sends a GET request to /contacts?search=1800444444
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly one contacts
+    And the JSON should contain:
+      """
+        [
+          { "first_name": "Reed", "last_name": "Richards", "email": "mrfantastic@ff.org" }
+        ]
+      """
+
+
+  Scenario: Search contacts matching on a phone number starting with the supplied value
+    Given the client sends a GET request to /contacts?search=1800
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly two contacts
+    And the JSON should contain:
+      """
+        [
+          { "first_name": "Reed", "last_name": "Richards", "email": "mrfantastic@ff.org" },
+          { "first_name": "Jessica", "last_name": "Jones", "email": "jewel@brooklyn.ny" }
+        ]
+      """
+
+
+  Scenario: Search contacts matching on a phone number containing with the supplied value
+            pg_search does not support contains/ends with matching on numbers
+    Given the client sends a GET request to /contacts?search=444
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly no contacts
+
+
+
+  Scenario: Search contacts matching first name and last name only
+    Given the client sends a GET request to /contacts?search=Jone Rich
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly one contact
+    And the JSON should contain:
+      """
+        [
+          { "first_name": "Richard", "last_name": "Jones", "email": "abomb@smash.org" }
+        ]
+      """
+
+
+  Scenario: Search contacts matching first name and state only
+    Given the client sends a GET request to /contacts?search=Rich AZ
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly one contact
+    And the JSON should contain:
+      """
+        [
+          { "first_name": "Richard", "last_name": "Jones", "email": "abomb@smash.org" }
+        ]
+      """
+
+
+  Scenario: Search contacts matching first name and last name
+    Given the client sends a GET request to /contacts?search=Richard
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly two contacts
+    And the JSON should contain:
+      """
+        [
+          { "first_name": "Richard", "last_name": "Jones", "email": "abomb@smash.org" },
+          { "first_name": "Reed", "last_name": "Richards", "email": "mrfantastic@ff.org" }
+        ]
+      """
+
+  
+  Scenario: Search contacts matching zip and phone number starting with the supplied value
+    Given the client sends a GET request to /contacts?search=180
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly two contacts
+    And the JSON should contain:
+      """
+        [
+          { "first_name": "Jessica", "last_name": "Jones", "email": "jewel@brooklyn.ny" },
+          { "first_name": "Reed", "last_name": "Richards", "email": "mrfantastic@ff.org" }
+        ]
+      """
+
+
+  Scenario: Search contacts matching zip and phone number ending with the supplied value
+            pg_search does not support contains/ends with matching on numbers
+    Given the client sends a GET request to /contacts?search=321
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly no contacts

--- a/features/partners/list_partners.feature
+++ b/features/partners/list_partners.feature
@@ -55,14 +55,3 @@ Feature: List Partners
        {"partner": true }
 
     """
-
-  @wip
-  Scenario: List partners when there are none
-    Given the client sends a GET request to /partners
-    Then a 200 status code is returned
-    And the response should be JSON
-    And the JSON should contain exactly:
-      """
-          []
-      """
-    

--- a/features/partners/search_partners.feature
+++ b/features/partners/search_partners.feature
@@ -1,0 +1,72 @@
+Feature: Search Partners
+  In order to find the partners I want
+  I need to be able to search them.
+  The search has all the features of a contacts search, but is limited to those contacts who are also partners
+
+  Background:
+    Given the following user is registered:
+      | first_name       | last_name      | email                       | password  |
+      | Charles          | Xavier         | x@westchester.ny            | jeanrules |
+
+    And the system knows about the following contacts:
+      | id | first_name       | last_name      | email                     | business_name          | city          | partner |
+      | 1  | Warren           | Worthington    | angel@w3.org              | Worthington Industries | North Salem   | true    |
+      | 2  | Jessica          | Jones          | jewel@brooklyn.ny         | Alias Investigations   | New York      | false   |
+      | 3  | Jean             | Grey           | jean@grey.me              | Uncanny X-Men R Us     | North Salem   | true    |
+      | 4  | Richard          | Jones          | abomb@smash.org           | Hulk, Inc              | Scarsdale     | true    |
+
+    And the client authenticates as x@westchester.ny/jeanrules
+
+  Scenario: Search partners (unauthenticated)
+    Given the client is not authenticated
+    When the client sends a GET request to /partners?search=Je
+    Then a 401 status code is returned
+
+
+  Scenario: Search partners resulting in no match
+            Jessica Jones is a contact but not a partner
+    Given the client sends a GET request to /partners?search=Jessica
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly no contacts
+
+
+  Scenario: Search partners matching on first name only
+    Given the client sends a GET request to /partners?search=Je
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly one contacts
+    And the JSON should contain:
+      """
+        [
+          { "first_name": "Jean", "last_name": "Grey", "email": "jean@grey.me" }
+        ]
+      """
+
+
+  Scenario: Search partners matching on last name only
+    Given the client sends a GET request to /partners?search=Jones
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly one contacts
+    And the JSON should contain:
+      """
+        [
+          { "first_name": "Richard", "last_name": "Jones", "email": "abomb@smash.org" }
+        ]
+      """
+
+
+
+  Scenario: Search partners matching on city
+    Given the client sends a GET request to /partners?search=Salem
+    Then a 200 status code is returned
+    And the response should be JSON
+    And the JSON should have exactly two contacts
+    And the JSON should contain:
+      """
+        [
+          { "first_name": "Warren", "last_name": "Worthington", "email": "angel@w3.org" },
+          { "first_name": "Jean", "last_name": "Grey", "email": "jean@grey.me" }
+        ]
+      """

--- a/features/step_definitions/rest_steps.rb
+++ b/features/step_definitions/rest_steps.rb
@@ -80,7 +80,8 @@ And(/^the JSON should have exactly (#{CAPTURE_INT}) ([\w+]+?)(?:s\b|\b)$/) do |c
   validate_list(data, type, count)
 end
 
-Then(/^the JSON should have at least (#{CAPTURE_INT}) (.*)s/) do |at_least, type|
+
+Then(/^the JSON should have at least (#{CAPTURE_INT}) ([\w+]+?)(?:s\b|\b)$/) do |at_least, type|
   data = JSON.parse(last_response.body)
   validate_list(data, type, nil, at_least)
 end


### PR DESCRIPTION
Closes #5 

There are some limitations, documented in the feature files - you can't search for email addresses, zip codes, or phone numbers containing the supplied value but you can search for them matching exactly or starting with the supplied value.
This is a limitation of pg_search.
We could look at a totally custom search if this isn't sufficient, but that starts to get complex when you want to match multiple fields, ranked in different ways, with multiple values.

I'd say go with this for now and revisit later if it is actually a problem